### PR TITLE
Fixed "create_attach_volumes" salt-cloud action for GCP

### DIFF
--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -2400,9 +2400,10 @@ def create_attach_volumes(name, kwargs, call=None):
             '-a or --action.'
         )
 
-    volumes = kwargs['volumes']
+    volumes = literal_eval(kwargs['volumes'])
     node = kwargs['node']
-    node_data = _expand_node(node)
+    conn = get_conn()
+    node_data = _expand_node(conn.ex_get_node(node))
     letter = ord('a') - 1
 
     for idx, volume in enumerate(volumes):
@@ -2412,9 +2413,9 @@ def create_attach_volumes(name, kwargs, call=None):
           'disk_name': volume_name,
           'location': node_data['extra']['zone']['name'],
           'size': volume['size'],
-          'type': volume['type'],
-          'image': volume['image'],
-          'snapshot': volume['snapshot']
+          'type': volume.get('type', 'pd-standard'),
+          'image': volume.get('image', None),
+          'snapshot': volume.get('snapshot', None)
         }
 
         create_disk(volume_dict, 'function')


### PR DESCRIPTION
Fixes #44088
    - "create_attach_volumes" salt-cloud works with mandatory and
      default arguments as mentioned in docstring of the function.

### What does this PR do?
With this fix, the user can create new volumes and attach it to existing instance.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/44088

### Previous Behavior
"create_attach_volumes" salt-cloud action was failing for GCP.

### New Behavior
"create_attach_volumes" salt-cloud action works for GCP.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
